### PR TITLE
Return infinite scrolling. Refactor to not allocate massive arrays.

### DIFF
--- a/RVCalendarWeekView/Lib/MSWeekView.h
+++ b/RVCalendarWeekView/Lib/MSWeekView.h
@@ -23,7 +23,6 @@
     NSMutableDictionary * mEventsGroupedByDay;
 }
 
-@property(strong, nonatomic) NSMutableDictionary* days;
 @property(strong,nonatomic) UICollectionView* collectionView;
 @property(strong,nonatomic) MSCollectionViewCalendarLayout* weekFlowLayout;
 


### PR DESCRIPTION
Previous version allocated massive "mDays" array. Refactor to "days" array killed infinite scrolling. This refactor returns infinite scrolling without massive array.
